### PR TITLE
Aruha 759 per event authz

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,7 @@
+Andrey Dyachkov <andrey.dyachkov@zalando.de>
+Dmitry Sorokin <dmitriy.sorokin@zalando.de>
+Ricardo De Cillo <ricardo.de.cillo@zalando.de>
+Valentine Gogichashvili <valentine.gogichashvili@zalando.de>
+Lionel Montrieux <lionel.montrieux@zalando.de>
+Vyacheslav Stepanov <vyacheslav.stepanov@zalando.de>
+Robert Garrett <robert.garrett@zalando.de>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Nakadi-plugin-api
+
+Nakadi-plugin-api is an API to develop extensions for [Nakadi](https://github.com/zalando/nakadi).
+
+## Build
+
+To build nakadi-plugin-api, run `gradle jar`. You may have to set bogus values for `sonatypeUsername` 
+and `sonatypePassword` in your `gradle.properties`.
+
+## Current plugin stubs
+
+### ApplicationService
+
+Plugins implementing ApplicationService are used to validate the `owning_application` field in an event type definition.
+
+### AuthorizationService
+
+Plugins implementing AuthorizationService are used to enforce per-event type and per-subscription authorization.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.zalando'
-version '1.0.5'
+version '1.1.0'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -39,12 +39,12 @@ uploadArchives {
                 name 'nakadi-plugin-api'
                 packaging 'jar'
                 description 'Nakadi API to write extensions'
-                url 'https://github.com/zalando/nakadi-plugin-api'
+                url 'https://github.com/zalando-incubator/nakadi-plugin-api'
 
                 scm {
-                    url 'scm:git@github.com:zalando/nakadi-plugin-api.git'
-                    connection 'scm:git@github.com:zalando/nakadi-plugin-api.git'
-                    developerConnection 'scm:git@github.com:zalando/nakadi-plugin-api.git'
+                    url 'scm:git@github.com:zalando-incubator/nakadi-plugin-api.git'
+                    connection 'scm:git@github.com:zalando-incubator/nakadi-plugin-api.git'
+                    developerConnection 'scm:git@github.com:zalando-incubator/nakadi-plugin-api.git'
                 }
 
                 licenses {
@@ -59,6 +59,10 @@ uploadArchives {
                     developer {
                         id 'v1ctor'
                         name 'Victor Buldakov'
+                    }
+                    developer {
+                        id 'lionel.montrieux@zalando.de'
+                        name 'Lionel Montrieux'
                     }
                 }
             }

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationAttribute.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationAttribute.java
@@ -1,0 +1,20 @@
+package org.zalando.nakadi.plugin.api.authz;
+
+public class AuthorizationAttribute {
+
+    private final String key;
+    private final String value;
+
+    public AuthorizationAttribute(final String key, final String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
@@ -1,0 +1,11 @@
+package org.zalando.nakadi.plugin.api.authz;
+
+import java.util.List;
+
+public interface AuthorizationService {
+
+    boolean isAuthorized(String token, List<AuthorizationAttribute> attributeList);
+
+    boolean isAuthorizationAttributeValid(AuthorizationAttribute attribute);
+
+}

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationServiceFactory.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationServiceFactory.java
@@ -1,0 +1,8 @@
+package org.zalando.nakadi.plugin.api.authz;
+
+import org.zalando.nakadi.plugin.api.SystemProperties;
+
+public interface AuthorizationServiceFactory {
+
+    AuthorizationService init(SystemProperties properties);
+}


### PR DESCRIPTION
ARUHA 759

This is the first PR to add support for per-event type authorization.

This PR not only defines a new extension point for Nakadi, it also adds some minimal documentation to the project, and a list of maintainers.